### PR TITLE
feat: StateChip  공용 컴포넌트 추가

### DIFF
--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 
-import ChipInput from '@/components/textchip/ChipInput';
 import ColorChip from '@/components/colorchip/ColorChip';
+import StateChipList from '@/components/statechip/StateChipList';
+import ChipInput from '@/components/textchip/ChipInput';
 
 export default function PlaygroundPage() {
   const [projects, setProjects] = useState<string[]>(['Test']);
@@ -27,6 +28,9 @@ export default function PlaygroundPage() {
         </form>
 
         <ColorChip />
+        <div className="mt-4">
+          <StateChipList />
+        </div>
       </section>
     </main>
   );

--- a/src/components/statechip/StateChipItem.tsx
+++ b/src/components/statechip/StateChipItem.tsx
@@ -1,0 +1,12 @@
+// StateChipItem.tsx
+
+export type StateLabel = 'To Do' | 'On Progress' | 'Done';
+
+export default function StateChipItem({ label }: { label: StateLabel }) {
+  return (
+    <div className="inline-flex w-fit items-center gap-2 px-3 py-1 text-sm rounded-full bg-[#F1EFFD] text-[#5534DA] whitespace-nowrap">
+      <span className="w-1.5 h-1.5 rounded-full bg-[#5534DA]" />
+      {label}
+    </div>
+  );
+}

--- a/src/components/statechip/StateChipList.tsx
+++ b/src/components/statechip/StateChipList.tsx
@@ -1,0 +1,15 @@
+// StateChipList.tsx
+import type { StateLabel } from './StateChipItem';
+import StateChipItem from './StateChipItem';
+
+const CHIPS: StateLabel[] = ['To Do', 'On Progress', 'Done'];
+
+export default function StateChipList() {
+  return (
+    <div className="flex flex-col gap-3">
+      {CHIPS.map((chip) => (
+        <StateChipItem key={chip} label={chip} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION

<img width="121" height="121" alt="스크린샷 2026-01-19 182756" src="https://github.com/user-attachments/assets/a2ee42e5-39a0-4eb9-b40c-b0e335844013" />
- 드롭다운에서 상태 선택 시 StateChip이 변경됨
- 상태별 스타일은 기존 디자인 기준 유지

