### PR TITLE
feat: #19 담당자 카드 컴포넌트(AssigneeCard) 추가

### DIFF
--- a/src/components/assigneeCard/AssigneeCard.tsx
+++ b/src/components/assigneeCard/AssigneeCard.tsx
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+
+export default function AssigneeCard({
+  name,
+  profileImg,
+  dueDate,
+}: {
+  name: string;
+  profileImg: string;
+  dueDate: string;
+}) {
+  return (
+    <div className="md:w-50 md:h-39 w-73.75 h-16 border border-[#D9D9D9] rounded-lg flex flex-col justify-center pl-4">
+      <div className="flex md:flex-col gap-16 md:gap-4">
+        <div className="flex flex-col md:gap-1.5">
+          <div className="h-5 flex items-center">
+            <span className="text-sm font-semibold leading-none text-black">담당자</span>
+          </div>
+          <div className="h-8.5 flex items-center gap-2">
+            <Image
+              src={profileImg}
+              alt={`${name} profile`}
+              width={34}
+              height={34}
+              sizes="(max-width: 767px) 26px, 34px"
+              className="h-6.5 w-6.5 rounded-full md:h-8.5 md:w-8.5"
+            />
+            <span className="text-xs md:text-sm leading-none text-[#333236]">{name}</span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 md:gap-1.5">
+          <div className="h-5 flex items-center">
+            <span className="text-sm font-semibold leading-none text-black">마감일</span>
+          </div>
+          <div className="h-6 flex items-center">
+            <span className="text-xs md:text-sm leading-none text-[#333236]">{dueDate}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용
- `AssigneeCard` 컴포넌트를 추가했습니다.
- 담당자 이름, 프로필 이미지, 마감일을 props로 받을 수 있도록 구성했습니다.
- 모바일/데스크톱에서 레이아웃이 달라지도록 반응형 스타일을 적용했습니다.
- 프로필 이미지는 모바일에서 `26px`, `md` 이상에서 `34px`로 보이도록 설정했습니다.
- `assigneeCard` 테스트 페이지와 샘플 프로필 이미지를 추가했습니다.

## 상세 변경
- `src/components/assigneeCard/AssigneeCard.tsx`
  - `name`, `profileImg`, `dueDate` props 기반 카드 UI 구현
  - `md:` breakpoint 기준으로 카드 크기, 간격, 폰트 크기 반응형 처리
  - `next/image`에 `sizes`와 반응형 width/height 클래스를 적용해 이미지 크기 조정

## 사용방법
```ts
export default function Page() {
  return (
    <div>
      <AssigneeCard name="김태스크" profileImg="/images/profile-sample.svg" dueDate="2026-03-30" />
    </div>
  );
```


## 테스트
- `assigneeCard` 페이지에서 카드 렌더링 확인
- 프로필 이미지가 모바일/데스크톱에서 각각 다른 크기로 보이는지 확인
- 담당자/마감일 텍스트 정렬 확인

<img width="877" height="173" alt="image" src="https://github.com/user-attachments/assets/64a8ff51-0471-4d89-986b-69249174d24a" />

